### PR TITLE
Fixed Z-Index of the Selected BannerViewItem

### DIFF
--- a/BannerView/Controls/BannerViewItem.cs
+++ b/BannerView/Controls/BannerViewItem.cs
@@ -57,7 +57,11 @@ namespace BannerView.Controls
             {
                 dropShadow.BlurRadius = IsSelected ? 8f : 0f;
             }
-        }
+			if(IsSelected)			
+				Canvas.SetZIndex(this, 1);
+			else
+				Canvas.SetZIndex(this, 0);
+		}
 
         private void InitComposition()
         {


### PR DESCRIPTION
When items spacing is small, the right BannerViewItem overlays the selected BannerViewItem. I fixed this problem.


![Banner](https://user-images.githubusercontent.com/30560453/70366006-11f81c80-1873-11ea-896d-e7e95dddfed8.png)